### PR TITLE
Implemented update logic for Word, Entry, Meaning.

### DIFF
--- a/Api/Controllers/MeaningController.cs
+++ b/Api/Controllers/MeaningController.cs
@@ -22,7 +22,7 @@ namespace Api.Controllers
             this.mapper = mapper;
         }
 
-        [HttpGet]
+        [HttpGet("{id}")]
         public ActionResult<GetMeaning> Get(int id)
         {
             var entity = repo.GetByID(id);

--- a/Commons/Constants.cs
+++ b/Commons/Constants.cs
@@ -32,8 +32,9 @@ namespace Commons
         
         public const String CANNOT_UPDATE = "Entity cannot be updated";
         public const String CANNOT_UPDATE_LANGUAGE_DESC = "Name property cannot be changed. If you want to add words to a Language, post them on their respective endpoint";
-        public const String CANNOT_UPDATE_DICTIONARY_DESC = "LanguageInName and LanguageOutName properties of a Dictionary cannot be updated. If you want to add Entries or FreeExpressions to a Dictionary, post them on their respective endpoints";
-        
+        public const String CANNOT_UPDATE_DICTIONARY_DESC = "LanguageInName and LanguageOutName properties of a Dictionary cannot be updated. If you want to add Entries or FreeExpressions to a Dictionary, post them on their respective endpoints.";
+        public const String CANNOT_UPDATE_ENTRY_DESC = "Properties of given Entry cannot be updated because the Entry already includes Meeanings. If you want to add Meanings to the Entry, post them on their respective endpoint.";
+
         public const String LANGUAGES_NOT_MATCH = "Language does not match";
         public const String LANGUAGES_NOT_MATCH_DESC = "SourceLanguage of the Word is different than LanguageIn of the Dictionary. The case is ignored";
         

--- a/Data/Dto/Word/UpdateWord.cs
+++ b/Data/Dto/Word/UpdateWord.cs
@@ -7,9 +7,8 @@ namespace Data.Dto
     public class UpdateWord
     {
         [Required]
-        public String SourceLanguageName { get; set; }
+        public String Value { get; set; }
 
-        [Required]
         public ISet<WordPropertyDto> Properties { get; set; } = new HashSet<WordPropertyDto>();
     }
 }

--- a/Data/Mapper/MappingConfig.cs
+++ b/Data/Mapper/MappingConfig.cs
@@ -40,7 +40,7 @@ namespace Data.Mapper
             RegisterMapping<UpdateWord, Word>(src =>
             {
                 Word result = new();
-                result.SourceLanguageName = src.SourceLanguageName;
+                result.Value = src.Value;
                 var func = ResolveMappingFunction<WordPropertyDto, WordProperty>();
                 foreach (var i in src.Properties)
                     result.Properties.Add(func(i));

--- a/Dictionary MVC/Properties/launchSettings.json
+++ b/Dictionary MVC/Properties/launchSettings.json
@@ -1,10 +1,10 @@
-﻿{
+{
   "iisSettings": {
-    "windowsAuthentication": false, 
-    "anonymousAuthentication": true, 
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:51384",
-      "sslPort": 44324
+      "applicationUrl": "http://localhost:50259/",
+      "sslPort": 44323
     }
   },
   "profiles": {
@@ -18,10 +18,10 @@
     "Dictionary_MVC": {
       "commandName": "Project",
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
     }
   }
 }

--- a/Service/Repository/Abstract/IEntryRepository.cs
+++ b/Service/Repository/Abstract/IEntryRepository.cs
@@ -41,5 +41,7 @@ namespace Service.Repository
         /// <param name="wordID"></param>
         /// <returns>a boolean</returns>
         public bool ExistsByWord(int wordID);
+
+        public bool HasMeanings(int id);
     }
 }

--- a/Service/Repository/EntryRepository.cs
+++ b/Service/Repository/EntryRepository.cs
@@ -61,5 +61,10 @@ namespace Service.Repository
         {
             return Exists(e => e.WordID == wordID);
         }
+
+        public bool HasMeanings(int id)
+        {
+            return context.Meanings.Any(m => m.EntryID == id);
+        }
     }
 }

--- a/Service/Repository/MeaningRepository.cs
+++ b/Service/Repository/MeaningRepository.cs
@@ -1,6 +1,5 @@
 ﻿using Data.Database;
 using Data.Models;
-using FluentValidation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
 using System;
@@ -53,6 +52,19 @@ namespace Service.Repository
             if (String.IsNullOrEmpty(valueSubstring))
                 return Enumerable.Empty<Meaning>();
             return Get(m => m.Entry.DictionaryIndex == dictionaryIndex && EF.Functions.Like(m.Value, $"%{valueSubstring}%"), x => x);
+        }
+        //Does not update EntryID
+        public override Meaning Update(Meaning entity)
+        {
+            //retrieve, change, update
+            var inDB = context.Meanings.Find(entity.ID);
+            context.Entry(inDB).Collection(m => m.Examples).Load();
+            inDB.Value = entity.Value;
+            inDB.Notes = entity.Notes;
+            inDB.Examples = entity.Examples;
+            context.SaveChanges();
+
+            return entity;
         }
     }
 }

--- a/Service/Repository/WordRepository.cs
+++ b/Service/Repository/WordRepository.cs
@@ -62,5 +62,17 @@ namespace Service.Repository
         {
             return Exists(w => w.ID == id);
         }
+
+        //So I think we should update Value and Properties. 
+        public override Word Update(Word entity)
+        {
+            var inDB = context.Words.Find(entity.ID);
+            context.Entry(inDB).Collection(w => w.Properties).Load();
+            inDB.Value = entity.Value;
+            inDB.Properties = entity.Properties;
+            context.SaveChanges();
+
+            return entity;
+        }
     }
 }

--- a/Service/Service/EntryService.cs
+++ b/Service/Service/EntryService.cs
@@ -35,6 +35,13 @@ namespace Service
         {
             this.validationDictionary = IValidationDictionary.New();
 
+            //check if has meanings. if it does, cancel updating
+            if (repo.HasMeanings(entity.ID))
+            {
+                validationDictionary.AddError(Msg.CANNOT_UPDATE, Msg.CANNOT_UPDATE_ENTRY_DESC);
+                return validationDictionary;
+            }
+
             //check if exists
             if (!repo.ExistsByID(entity.ID))
             {
@@ -60,7 +67,10 @@ namespace Service
             }
 
             //one entry per word
-            if (repo.ExistsByWord(entity.WordID))
+            var existing = repo.GetOne(e => e.WordID == entity.WordID);
+            //"Duplicate" Entry exists and its ID is different as the entity's ID - that means this is another Entry with same WordID.
+            //If the duplicate's and entity's ID are the same that means an entry is being updated - no error should be returned.
+            if (existing != null && existing.ID != entity.ID)
             {
                 validationDictionary.AddError(Msg.DUPLICATE, Msg.DUPLICATE_ENTRY_DESC);
                 return;
@@ -80,7 +90,6 @@ namespace Service
             {
                 validationDictionary.AddError(Msg.LANGUAGES_NOT_MATCH, Msg.LANGUAGES_NOT_MATCH_DESC);
             }
-
         }
     }
 }

--- a/Service/Service/MeaningService.cs
+++ b/Service/Service/MeaningService.cs
@@ -38,8 +38,6 @@ namespace Service
                 return validationDictionary;
             }
 
-            CheckEntry(entity);
-
             if (validationDictionary.IsValid)
                 repo.Update(entity);
 

--- a/Service/Service/WordService.cs
+++ b/Service/Service/WordService.cs
@@ -21,7 +21,8 @@ namespace Service
         {
             this.validationDictionary = IValidationDictionary.New();
 
-            CheckLanguageAndProperties(entity);
+            CheckLanguage(entity);
+            CheckValueAndProperties(entity);
 
             if (validationDictionary.IsValid)
                 repo.Create(entity);
@@ -40,8 +41,8 @@ namespace Service
                 return validationDictionary;
             }
 
-            //now, same checks as for adding
-            CheckLanguageAndProperties(entity);
+            //We don't check for Language because it cannot be updated.
+            CheckValueAndProperties(entity);
 
             if (validationDictionary.IsValid)
                 repo.Update(entity);
@@ -49,15 +50,8 @@ namespace Service
             return validationDictionary;
         }
 
-        private void CheckLanguageAndProperties(Word entity)
+        private void CheckValueAndProperties(Word entity)
         {
-            //check if language exists
-            if (!langRepo.ExistsByName(entity.SourceLanguageName))
-            {
-                validationDictionary.AddError(Msg.NOTFOUND<Language>(), Msg.NOTFOUND_DESC<Word, Language>(l => l.Name, entity.SourceLanguageName));
-                return;
-            }
-
             //check if there's a word with same set of WordProperties
             var similar = repo.GetByLanguageAndValue(entity.SourceLanguageName, entity.Value, false);
             foreach (var i in similar)
@@ -66,6 +60,16 @@ namespace Service
                 {
                     validationDictionary.AddError(Msg.DUPLICATE, Msg.DUPLICATE_WORD_DESC);
                 }
+            }
+        }
+
+        private void CheckLanguage(Word entity)
+        {
+            //check if language exists
+            if (!langRepo.ExistsByName(entity.SourceLanguageName))
+            {
+                validationDictionary.AddError(Msg.NOTFOUND<Language>(), Msg.NOTFOUND_DESC<Word, Language>(l => l.Name, entity.SourceLanguageName));
+                return;
             }
         }
     }

--- a/Service/Validation/UpdateWordValidator.cs
+++ b/Service/Validation/UpdateWordValidator.cs
@@ -4,11 +4,11 @@ using FluentValidation;
 
 namespace Service.Validation
 {
-    class UpdateWordValidator : AbstractValidator<UpdateWord>
+    public class UpdateWordValidator : AbstractValidator<UpdateWord>
     {
         public UpdateWordValidator()
         {
-            RuleFor(w => w.SourceLanguageName).NotEmpty().WithMessage(MessageConstants.NOT_EMPTY).NoDigitsNoSpaces();
+            RuleFor(w => w.Value).NotEmpty().NoDigits();
             RuleForEach(w => w.Properties).SetValidator(new WordPropertyDtoValidator());
         }
     }


### PR DESCRIPTION
Word: Value and Properties can be changed.
Entry: Dictionary and Word can be changed as long as Entry has no Meanings.
Meaning: Value, Notes, Examples can be changed.

I implemented this logic for Entry because it could cause problems if suddenly the Word changed and the Meanings would point to other word. Though, the Word's value and properties can change, so I'm wondering if it's sensible to do that. It's hard to tell if it will have much impact on the users (if there will be any ever  ; )  ). For now it stays like that, changing it is not a headache.
Closes  #194 