### PR TITLE
Test Word update logic. Some fun with database collations.

### DIFF
--- a/Data/Data.csproj
+++ b/Data/Data.csproj
@@ -5,6 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Database\Migrations\**" />
+    <EmbeddedResource Remove="Database\Migrations\**" />
+    <None Remove="Database\Migrations\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="5.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.0"></PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.0" />
@@ -15,10 +21,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Database\Migrations\" />
   </ItemGroup>
 
 </Project>

--- a/Data/Database/DatabaseContext.cs
+++ b/Data/Database/DatabaseContext.cs
@@ -28,6 +28,7 @@ namespace Data.Database
             #region languages and words and wordproperties
 
             builder.Entity<Language>().ToTable("Language");
+
             var word = builder.Entity<Word>().ToTable("Word");
 
             word
@@ -35,6 +36,10 @@ namespace Data.Database
                 .WithOne(entry => entry.Word)
                 .HasForeignKey<Entry>(entry => entry.WordID)
                 .OnDelete(DeleteBehavior.Cascade); //deleting all entries that contain given word
+
+            word
+                .Property(word => word.Value)
+                .UseCollation("SQL_Latin1_General_CP1_CS_AS");
 
             builder.Entity<WordProperty>().ToTable("WordProperty");
 

--- a/Data/Migrations/20201217170241_LanguagesAndWords.cs
+++ b/Data/Migrations/20201217170241_LanguagesAndWords.cs
@@ -10,7 +10,8 @@ namespace Data.Migrations
                 name: "Language",
                 columns: table => new
                 {
-                    Name = table.Column<string>(type: "nvarchar(450)", nullable: false)
+                    //Name = table.Column<string>(type: "nvarchar(450)", nullable: false)
+                    Name = table.Column<string>(type: "nvarchar(450)", nullable: false, collation: "SQL_Latin1_General_CP1_CS_AS")
                 },
                 constraints: table =>
                 {
@@ -23,7 +24,8 @@ namespace Data.Migrations
                 {
                     ID = table.Column<int>(type: "int", nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
-                    SourceLanguageName = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    SourceLanguageName = table.Column<string>(type: "nvarchar(450)", nullable: false, collation: "SQL_Latin1_General_CP1_CS_AS"),
+                    //SourceLanguageName = table.Column<string>(type: "nvarchar(450)", nullable: false),
                     Value = table.Column<string>(type: "nvarchar(max)", nullable: false)
                 },
                 constraints: table =>

--- a/Data/Migrations/20201217172917_DictionariesAndEverythingBelow.cs
+++ b/Data/Migrations/20201217172917_DictionariesAndEverythingBelow.cs
@@ -10,8 +10,10 @@ namespace Data.Migrations
                 name: "Dictionary",
                 columns: table => new
                 {
-                    LanguageInName = table.Column<string>(type: "nvarchar(450)", nullable: false),
-                    LanguageOutName = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    LanguageInName = table.Column<string>(type: "nvarchar(450)", nullable: false, collation: "SQL_Latin1_General_CP1_CS_AS"),
+                    //LanguageInName = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    LanguageOutName = table.Column<string>(type: "nvarchar(450)", nullable: false, collation: "SQL_Latin1_General_CP1_CS_AS"),
+                    //LanguageOutName = table.Column<string>(type: "nvarchar(450)", nullable: false),
                     Index = table.Column<int>(type: "int", nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1")
                 },

--- a/Data/Migrations/20210125170700_WordValueCaseSensitive.Designer.cs
+++ b/Data/Migrations/20210125170700_WordValueCaseSensitive.Designer.cs
@@ -4,14 +4,16 @@ using Data.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Data.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20210125170700_WordValueCaseSensitive")]
+    partial class WordValueCaseSensitive
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Data/Migrations/20210125170700_WordValueCaseSensitive.cs
+++ b/Data/Migrations/20210125170700_WordValueCaseSensitive.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Data.Migrations
+{
+    public partial class WordValueCaseSensitive : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Value",
+                table: "Word",
+                type: "nvarchar(max)",
+                nullable: false,
+                collation: "SQL_Latin1_General_CP1_CS_AS",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Value",
+                table: "Word",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldCollation: "SQL_Latin1_General_CP1_CS_AS");
+        }
+    }
+}

--- a/Service.Tests/Service/WordServiceTests.cs
+++ b/Service.Tests/Service/WordServiceTests.cs
@@ -191,7 +191,6 @@ namespace Service.Tests.Service
         // - Change value to lower/uppercase
         // - Change properties to lower/uppercase
         // - Clear properties
-        //TODO those tests are fucking stupid, they should be changed.
         [Fact]
         public void TryUpdate_ChangePropertiesToDifferent_UpdatesProperly()
         {

--- a/Service.Tests/Service/WordServiceTests.cs
+++ b/Service.Tests/Service/WordServiceTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
+using Humanizer;
 
 namespace Service.Tests.Service
 {
@@ -20,6 +21,35 @@ namespace Service.Tests.Service
             langRepo = _langRepo;
             service = new WordService(this.uow.Object);
         }
+
+        private Word dummy => new Word
+        {
+            ID = 13,
+            SourceLanguageName = "polish",
+            Properties = new()
+            {
+                new()
+                {
+                    ID = 5,
+                    Name = "gender",
+                    Values = new("masculine", "feminine")
+                },
+
+                new()
+                {
+                    ID = 6,
+                    Name = "plural form",
+                    Values = new("przeręble")
+                },
+
+                new()
+                {
+                    ID = 7,
+                    Name = "genitive form",
+                    Values = new("przerębla", "przerębli")
+                }
+            }
+        };
 
         [Fact]
         public void TryAdd_LanguageExists_PropertiesGood_ShouldAdd()
@@ -135,7 +165,7 @@ namespace Service.Tests.Service
         }
 
         [Fact]
-        public void TryUpdate_WordFound_EverythingGodd_ReturnsNoErrors()
+        public void TryUpdate_WordFound_EverythingGodd_UpdatesProperly()
         {
             var entity = new Word
             {
@@ -152,6 +182,206 @@ namespace Service.Tests.Service
             _wordRepo.Verify(_ => _.Update(It.IsAny<Word>()), Times.Once);
             Assert.Empty(result);
             Assert.True(result.IsValid);
+        }
+
+        // Attempt:
+        // - Change only Properties
+        // - Change Value
+        // - Change both
+        // - Change value to lower/uppercase
+        // - Change properties to lower/uppercase
+        // - Clear properties
+        //TODO those tests are fucking stupid, they should be changed.
+        [Fact]
+        public void TryUpdate_ChangePropertiesToDifferent_UpdatesProperly()
+        {
+            WordPropertySet props = new()
+            {
+                new()
+                {
+                    Name = "name1",
+                    Values = new("value1", "value2")
+                },
+
+                new()
+                {
+                    Name = "name2",
+                    Values = new("value1")
+                }
+            };
+
+            var existing = dummy;
+            Word @new = new()
+            {
+                ID = existing.ID,
+                Value = existing.Value,
+                Properties = props
+            };
+            //test merging languagename on living organism
+
+            _wordRepo.Setup(_ => _.ExistsByID(It.Is<int>(i => i == @new.ID))).Returns(true);
+            //that should return 'existing', the word that is gonna be updated with '@new'
+            _wordRepo.Setup(_ => _.GetByLanguageAndValue(@new.SourceLanguageName, @new.Value, false))
+                .Returns(new Word[]{ existing });
+
+
+            var result = service.TryUpdate(@new);
+
+            _wordRepo.Verify(_ => _.Update(It.IsAny<Word>()), Times.Once);
+            Assert.True(result.IsValid);
+        }
+
+        [Fact]
+        public void TryUpdate_ChangeValueToDifferent_UpdatesProperly()
+        {
+            var existing = dummy;
+            Word @new = new()
+            {
+                ID = existing.ID,
+                Properties = existing.Properties,
+                Value = "a different value",
+            };
+
+            _wordRepo.Setup(_ => _.ExistsByID(It.Is<int>(i => i == @new.ID))).Returns(true);
+            //no other Words match this Word's Value because it was changed.
+            _wordRepo.Setup(_ => _.GetByLanguageAndValue(@new.SourceLanguageName, @new.Value, false))
+                .Returns(Enumerable.Empty<Word>());
+
+            var result = service.TryUpdate(@new);
+
+            _wordRepo.Verify(_ => _.Update(It.IsAny<Word>()), Times.Once);
+            Assert.True(result.IsValid);
+        }
+
+        [Fact]
+        public void TryUpdate_ChangePropertiesAndValue_UpdatesProperly()
+        {
+            var existing = dummy;
+            Word @new = new()
+            {
+                ID = existing.ID,
+                Properties = new()
+                {
+                    new()
+                    {
+                        Name = "name",
+                        Values = new("values")
+                    }
+                },
+                Value = "new value",
+            };
+
+            _wordRepo.Setup(_ => _.ExistsByID(It.Is<int>(i => i == @new.ID))).Returns(true);
+            //no other Words match this Word's Value because it was changed.
+            _wordRepo.Setup(_ => _.GetByLanguageAndValue(@new.SourceLanguageName, @new.Value, false))
+                .Returns(Enumerable.Empty<Word>());
+
+            var result = service.TryUpdate(@new);
+
+            _wordRepo.Verify(_ => _.Update(It.IsAny<Word>()), Times.Once);
+            Assert.True(result.IsValid);
+        }
+
+        [Fact]
+        //so it returns the same word as the commited one
+        public void TryUpdate_ChangeCaseOfValue_WordWithThatCaseAlreadyExists_ReturnsError()
+        {
+            var existing = dummy;
+            existing.Value = "value";
+            Word @new = new()
+            {
+                ID = existing.ID,
+                Properties = existing.Properties,
+                Value = "Value"
+            };
+
+            _wordRepo.Setup(_ => _.ExistsByID(It.Is<int>(i => i == @new.ID))).Returns(true);
+            _wordRepo.Setup(_ => _.GetByLanguageAndValue(@new.SourceLanguageName, @new.Value, false))
+                .Returns(new Word[]{ @new });
+
+            var result = service.TryUpdate(@new);
+
+            _wordRepo.Verify(_ => _.Update(It.IsAny<Word>()), Times.Never);
+            Assert.False(result.IsValid);
+        }
+
+        [Fact]
+        public void TryUpdate_ChangeCaseOfValue_UpdatesProperly()
+        {
+            //so basically the same as previously but the duplicate does not exist?
+            var existing = dummy;
+            existing.Value = "value";
+            Word @new = new()
+            {
+                ID = existing.ID,
+                Properties = existing.Properties,
+                Value = "Value"
+            };
+
+            _wordRepo.Setup(_ => _.ExistsByID(It.Is<int>(i => i == @new.ID))).Returns(true);
+            _wordRepo.Setup(_ => _.GetByLanguageAndValue(@new.SourceLanguageName, @new.Value, false))
+                .Returns(Array.Empty<Word>());
+
+            var result = service.TryUpdate(@new);
+
+            _wordRepo.Verify(_ => _.Update(It.IsAny<Word>()), Times.Once);
+            Assert.True(result.IsValid);
+        }
+
+        //case of properties should be ignored
+        [Fact]
+        public void TryUpdate_ChangePropertiesCase_WordWithSuchPropertiesAlreadyExists_ReturnsError()
+        {
+            var existing = new Word
+            {
+                ID = 11,
+                SourceLanguageName = "polish",
+                Value = "some value",
+                Properties = new()
+                {
+                    new()
+                    {
+                        Name = "name1",
+                        Values = new("value1")
+                    },
+
+                    new()
+                    {
+                        Name = "name2",
+                        Values = new("value1", "value2")
+                    }
+                }
+            };
+
+            var @new = new Word
+            {
+                ID = 11,
+                SourceLanguageName = "polish",
+                Value = "some value",
+                Properties = new()
+                {
+                    new()
+                    {
+                        Name = "Name1",
+                        Values = new("VALue1")
+                    },
+
+                    new()
+                    {
+                        Name = "NAme2",
+                        Values = new("Value1", "value2")
+                    }
+                }
+            };
+
+            _wordRepo.Setup(_ => _.ExistsByID(It.Is<int>(i => i == @new.ID))).Returns(true);
+            _wordRepo.Setup(_ => _.GetByLanguageAndValue(@new.SourceLanguageName, @new.Value, false))
+                .Returns(new Word[] { existing });
+
+            var result = service.TryUpdate(@new);
+
+            _wordRepo.Verify(_ => _.Update(It.IsAny<Word>()), Times.Never);
+            Assert.False(result.IsValid);
         }
     }
 }

--- a/Service/Repository/LanguageRepository.cs
+++ b/Service/Repository/LanguageRepository.cs
@@ -13,7 +13,7 @@ namespace Service.Repository
     
     public class LanguageRepository : RepositoryBase<Language>, ILanguageRepository
     {
-        private readonly Func<IQueryable<Language>, IIncludableQueryable<Language, object>> includeQuery = 
+        private readonly Func<IQueryable<Language>, IIncludableQueryable<Language, object>> includeQuery =
             (languages => languages.Include(l => l.Words).ThenInclude(w => w.Properties));
 
         public LanguageRepository(DatabaseContext context):base(context) { }
@@ -27,7 +27,7 @@ namespace Service.Repository
 
         public Language GetByName(String name)
         {
-            return repo.Find(name);
+            return repo.FirstOrDefault(l => l.Name == name);
         }
 
         public Language GetByNameWithWords(String name)
@@ -35,6 +35,7 @@ namespace Service.Repository
             return GetOne(l => l.Name == name, null, includeQuery);
         }
 
+        //unused method, should be deleted
         public Language GetOneWithWords(Expression<Func<Language, bool>> condition)
         {
             return GetOne(condition, null, includeQuery);
@@ -46,9 +47,10 @@ namespace Service.Repository
             base.Create(entity);
         }
 
-        public bool ExistsByName(string name)
+        //case sensitive
+        public bool ExistsByName(String name)
         {
-            return Exists(l => EF.Functions.Like(l.Name, $"{name}"));
+            return Exists(l => l.Name == name);
         }
 
         public IEnumerable<LanguageWordCount> AllWithWordCount()


### PR DESCRIPTION
So it seems that using String == String and EF.Functions.Like() in DB queries results in the same same case-sensitivity.
That's why I changed collations to case-sensitive [here](https://github.com/Yanitrix/Dictionary/commit/974736b92856bed1767df5ec7ad0956242e8228a). 
Then, every case-insensitive query is made using EF.Functions.Collate(), basically explicitly stating the case-insesntive collation.
I don't know if it will result in loss of data since nvarchar is UTF8 and these collations are Latin1_General, but with tested data (polish, german signs) the tests pass. That's why LanguageRepository was also changed, since I changed the collation in Language.Name and Word.Value.
WordServiceTests pass though I don't know if they're the highest quality. But RN I can't think of anything more/better.