### PR TITLE
Test entry update logic. Change unique constraint on Entry

### DIFF
--- a/Commons/Constants.cs
+++ b/Commons/Constants.cs
@@ -36,7 +36,7 @@ namespace Commons
         public const String CANNOT_UPDATE_ENTRY_DESC = "Properties of given Entry cannot be updated because the Entry already includes Meeanings. If you want to add Meanings to the Entry, post them on their respective endpoint.";
 
         public const String LANGUAGES_NOT_MATCH = "Language does not match";
-        public const String LANGUAGES_NOT_MATCH_DESC = "SourceLanguage of the Word is different than LanguageIn of the Dictionary. The case is ignored";
+        public const String LANGUAGES_NOT_MATCH_DESC = "SourceLanguage of the Word is different than LanguageIn of the Dictionary. The case is NOT ignored";
         
         public static String NOTFOUND<T>() => $"{typeof(T).Name} not found";
         public static String DOESNT_EXIST_DESC<T>() => $"{typeof(T).Name} with given primary key does not exist in the database. There is nothing to update";

--- a/Data/Database/DatabaseContext.cs
+++ b/Data/Database/DatabaseContext.cs
@@ -88,8 +88,10 @@ namespace Data.Database
                 .HasForeignKey(dictionary => dictionary.LanguageOutName)
                 .OnDelete(DeleteBehavior.Restrict);
 
+            //well, it didn't work. Entry uniqueness should be determined upon its WordID and DictionaryIndex.
+            //The combination of those should be unique
             entry
-                .HasIndex(entry => entry.WordID)  //a word can be in only one entry, i'm not quite sure if it's the correct way to do it but i think it'll work
+                .HasIndex(entry => new { entry.WordID, entry.DictionaryIndex })  //there can be only one Entry in each Dictionary referring to a certain Word
                 .IsUnique();
 
             #endregion

--- a/Data/Migrations/20210129104929_EntryHasUniqueWordAndDictionary.Designer.cs
+++ b/Data/Migrations/20210129104929_EntryHasUniqueWordAndDictionary.Designer.cs
@@ -4,14 +4,16 @@ using Data.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Data.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20210129104929_EntryHasUniqueWordAndDictionary")]
+    partial class EntryHasUniqueWordAndDictionary
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Data/Migrations/20210129104929_EntryHasUniqueWordAndDictionary.cs
+++ b/Data/Migrations/20210129104929_EntryHasUniqueWordAndDictionary.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Data.Migrations
+{
+    public partial class EntryHasUniqueWordAndDictionary : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Entry_WordID_DictionaryIndex",
+                table: "Entry",
+                columns: new[] { "WordID", "DictionaryIndex" },
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Entry_WordID_DictionaryIndex",
+                table: "Entry");
+        }
+    }
+}

--- a/Service/Repository/Abstract/IEntryRepository.cs
+++ b/Service/Repository/Abstract/IEntryRepository.cs
@@ -15,7 +15,7 @@ namespace Service.Repository
         /// <param name="dictionaryIndex"></param>
         /// <param name="wordValue"></param>
         /// <returns>Matching collection</returns>
-        public IEnumerable<Entry> GetByDictionaryAndWord(int dictionaryIndex, String wordValue);
+        public IEnumerable<Entry> GetByDictionaryAndWord(int dictionaryIndex, String wordValue, bool caseSensitive = true);
 
         /// <summary>
         /// Including Word and its Properties, Meanings and their Examples, Dictionary
@@ -23,7 +23,7 @@ namespace Service.Repository
         /// </summary>
         /// <param name="wordValue"></param>
         /// <returns></returns>
-        public IEnumerable<Entry> GetByWord(String wordValue);
+        public IEnumerable<Entry> GetByWord(String wordValue, bool caseSensitive = true);
 
         /// <summary>
         /// Returns all Entries owned by certain Dictionary
@@ -34,13 +34,6 @@ namespace Service.Repository
         public IEnumerable<Entry> GetByDictionary(int dictionaryIndex);
 
         public bool ExistsByID(int id);
-
-        /// <summary>
-        /// Checks if theres already another Entry that contains Word of given ID
-        /// </summary>
-        /// <param name="wordID"></param>
-        /// <returns>a boolean</returns>
-        public bool ExistsByWord(int wordID);
 
         public bool HasMeanings(int id);
     }

--- a/Service/Service/EntryService.cs
+++ b/Service/Service/EntryService.cs
@@ -35,17 +35,17 @@ namespace Service
         {
             this.validationDictionary = IValidationDictionary.New();
 
-            //check if has meanings. if it does, cancel updating
-            if (repo.HasMeanings(entity.ID))
-            {
-                validationDictionary.AddError(Msg.CANNOT_UPDATE, Msg.CANNOT_UPDATE_ENTRY_DESC);
-                return validationDictionary;
-            }
-
             //check if exists
             if (!repo.ExistsByID(entity.ID))
             {
                 validationDictionary.AddError(Msg.DOESNT_EXIST, Msg.DOESNT_EXIST_DESC<Entry>());
+                return validationDictionary;
+            }
+
+            //check if has meanings. if it does, cancel updating
+            if (repo.HasMeanings(entity.ID))
+            {
+                validationDictionary.AddError(Msg.CANNOT_UPDATE, Msg.CANNOT_UPDATE_ENTRY_DESC);
                 return validationDictionary;
             }
 
@@ -67,9 +67,9 @@ namespace Service
             }
 
             //one entry per word
-            var existing = repo.GetOne(e => e.WordID == entity.WordID);
-            //"Duplicate" Entry exists and its ID is different as the entity's ID - that means this is another Entry with same WordID.
-            //If the duplicate's and entity's ID are the same that means an entry is being updated - no error should be returned.
+            var existing = repo.GetOne(e => e.WordID == entity.WordID && e.DictionaryIndex == entity.DictionaryIndex);
+            //If there's another entry another Entry with same WordID and DictionaryIndex, it's a possible duplicate
+            //If the duplicate's ID is the same as the Entity's that means that the Entry is being updated. I think no error should be returned here.
             if (existing != null && existing.ID != entity.ID)
             {
                 validationDictionary.AddError(Msg.DUPLICATE, Msg.DUPLICATE_ENTRY_DESC);
@@ -86,7 +86,7 @@ namespace Service
             //check if word's source language is dictionary's language in
             var word = wordRepo.GetByID(entity.WordID);
             var dict = dictRepo.GetByIndex(entity.DictionaryIndex);
-            if (!String.Equals(word.SourceLanguageName, dict.LanguageInName, StringComparison.OrdinalIgnoreCase))
+            if (!String.Equals(word.SourceLanguageName, dict.LanguageInName, StringComparison.Ordinal))
             {
                 validationDictionary.AddError(Msg.LANGUAGES_NOT_MATCH, Msg.LANGUAGES_NOT_MATCH_DESC);
             }


### PR DESCRIPTION
First of all, the previous unique constraint on Entry (Entry.WordID) was wrongly done because it prevented from creating any Entry of the same Word in any Dictionary except the one of the existing Entry. So the unique constraint should be 
    
    { Entry.WordID, Entry.DictionaryIndex }

Did migration, updated database.

I did the tests od EntryRepository and EntryService. All pass.